### PR TITLE
feat: delete plant from plot on plot index page

### DIFF
--- a/app/controllers/plot_plants_controller.rb
+++ b/app/controllers/plot_plants_controller.rb
@@ -1,0 +1,15 @@
+class PlotPlantsController < ApplicationController
+  before_action :set_plot_plant, only: :destroy
+  
+  def destroy
+    PlotPlant.destroy(@plot_plant.id)
+
+    redirect_to plots_path
+  end
+
+  private
+
+  def set_plot_plant
+    @plot_plant = PlotPlant.find(params[:id])
+  end
+end

--- a/app/views/plots/index.html.erb
+++ b/app/views/plots/index.html.erb
@@ -1,12 +1,17 @@
 <h1>Plots</h1>
 
 <div id="all-plots">
-  <% @plots.each do |p| %>
-    <div id="plot-<%= p.id %>">
-      <h3><%= "Plot #{p.number}" %></h3>
+  <% @plots.each do |plot| %>
+    <div id="plot-<%= plot.id %>">
+      <h3><%= "Plot #{plot.number}" %></h3>
       <ul>
-        <% p.plants.each do |plant| %>
-          <li><%= plant.name %></li>
+        <% plot.plot_plants.each do |plot_plant| %>
+          <li id="plot-plant-<%= plot_plant.id %>">
+            <%= plot_plant.plant.name %>
+            <%= form_with model: plot_plant, method: :delete do |f| %>
+              <%= f.button "Delete", method: :delete %>
+            <% end %>
+          </li>
         <% end %>
       </ul>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   # root "articles#index"
 
   resources :plots, only: :index
+  resources :plot_plants, only: :destroy
 end

--- a/spec/features/plots/index_spec.rb
+++ b/spec/features/plots/index_spec.rb
@@ -19,16 +19,16 @@ RSpec.describe "Plots Index Page", type: :feature do
     @plant_4 = Plant.create!(name: Faker::Food.unique.vegetables, description: Faker::Quotes::Shakespeare.hamlet_quote, days_to_harvest: 100)
 
     # Add plants to plots
-    @plot_a1.plants << @plant_1
-    @plot_a1.plants << @plant_2
-    @plot_a1.plants << @plant_3
+    @plot_a1_plant_1 = PlotPlant.create!(plot_id: @plot_a1.id, plant_id: @plant_1.id)
+    @plot_a1_plant_2 = PlotPlant.create!(plot_id: @plot_a1.id, plant_id: @plant_2.id)
+    @plot_a1_plant_3 = PlotPlant.create!(plot_id: @plot_a1.id, plant_id: @plant_3.id)
 
-    @plot_a2.plants << @plant_2
-    @plot_a2.plants << @plant_3
-    @plot_a2.plants << @plant_4
+    @plot_a2_plant_2 = PlotPlant.create!(plot_id: @plot_a2.id, plant_id: @plant_2.id)
+    @plot_a2_plant_3 = PlotPlant.create!(plot_id: @plot_a2.id, plant_id: @plant_3.id)
+    @plot_a2_plant_4 = PlotPlant.create!(plot_id: @plot_a2.id, plant_id: @plant_4.id)
 
-    @plot_b1.plants << @plant_3
-    @plot_b1.plants << @plant_4
+    @plot_b1_plant_3 = PlotPlant.create!(plot_id: @plot_b1.id, plant_id: @plant_3.id)
+    @plot_b1_plant_4 = PlotPlant.create!(plot_id: @plot_b1.id, plant_id: @plant_4.id)
   end
 
   it "has a list of every plot number" do
@@ -40,24 +40,46 @@ RSpec.describe "Plots Index Page", type: :feature do
     end
   end
 
-  it "shows a list each plot's plant under the plot number" do
-    visit plots_path
+  describe "plot plants" do
+    it "shows a list each plot's plants under the plot number" do
+      visit plots_path
 
-    within("#plot-#{@plot_a1.id}") do
-      expect(page).to have_content(@plant_1.name).once
-      expect(page).to have_content(@plant_2.name).once
-      expect(page).to have_content(@plant_3.name).once
+      within("#plot-#{@plot_a1.id}") do
+        expect(page).to have_content(@plant_1.name).once
+        expect(page).to have_content(@plant_2.name).once
+        expect(page).to have_content(@plant_3.name).once
+      end
+
+      within("#plot-#{@plot_a2.id}") do
+        expect(page).to have_content(@plant_2.name).once
+        expect(page).to have_content(@plant_3.name).once
+        expect(page).to have_content(@plant_4.name).once
+      end
+
+      within("#plot-#{@plot_b1.id}") do
+        expect(page).to have_content(@plant_3.name).once
+        expect(page).to have_content(@plant_4.name).once
+      end
     end
 
-    within("#plot-#{@plot_a2.id}") do
-      expect(page).to have_content(@plant_2.name).once
-      expect(page).to have_content(@plant_3.name).once
-      expect(page).to have_content(@plant_4.name).once
-    end
+    it "each plot's plant has a button near it that removes the plant from the plot" do
+      visit plots_path
 
-    within("#plot-#{@plot_b1.id}") do
-      expect(page).to have_content(@plant_3.name).once
-      expect(page).to have_content(@plant_4.name).once
+      within("#plot-#{@plot_a1.id}") do
+        expect(page).to have_content(@plot_a1_plant_1.plant.name)
+      end
+
+      within("#plot-plant-#{@plot_a1_plant_1.id}") do
+        expect(page).to have_button("Delete")
+
+        click_button "Delete"
+      end
+
+      expect(current_path).to eq(plots_path)
+
+      within("#plot-#{@plot_a1.id}") do
+        expect(page).to_not have_content(@plot_a1_plant_1.plant.name)
+      end
     end
   end
 end


### PR DESCRIPTION
complete story 2

```
User Story 2, Remove a Plant from a Plot

As a visitor
When I visit the plots index page
Next to each plant's name
I see a link to remove that plant from that plot
When I click on that link
I'm returned to the plots index page
And I no longer see that plant listed under that plot,
And I still see that plant's name under other plots that is was associated with.

Note: you do not need to test for any sad paths or implement any flash messages. 
```

